### PR TITLE
Fix interleave example

### DIFF
--- a/solutions/just-enough-clojure.clj
+++ b/solutions/just-enough-clojure.clj
@@ -68,7 +68,7 @@
 (def solution
      (fn [s]
        (take (dec (* 2 (count s)))
-             (interleave s (replicate (count s) _)))))
+             (interleave s (replicate (count s) '_)))))
 (solution [1 3 5 7])
 
 ;; DROP and DROP-LAST


### PR DESCRIPTION
I was getting "java.lang.Exception: Unable to resolve symbol: _ in this context (NO_SOURCE_FILE:78)" from this example, I assume you meant to quote the underscore.
